### PR TITLE
Use a recent minio image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,12 +21,10 @@ services:
     environment:
       - SERVICES=sns,sqs,apigateway
   db-zotero-minio:
-    image: minio/minio
-    build:
-      context: ./minio
+    image: minio/minio:RELEASE.2022-12-12T19-27-27Z
     environment:
-      - MINIO_ACCESS_KEY=zotero
-      - MINIO_SECRET_KEY=zoterodocker
+      - MINIO_ROOT_USER=zotero
+      - MINIO_ROOT_PASSWORD=zoterodocker
     volumes:
       - minio_data:/data
     command: server /data


### PR DESCRIPTION
The original minio executable was failing to run with the following error

db-zotero-minio_1          | ERROR Unable to initialize backend: format.json file: expected format-type: fs, found: xl-single. 

Using the updated image without changing the executable worked fine for me, not sure why it was overridden at first